### PR TITLE
Fix ng-src property for selectedTheme of model

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -315,7 +315,7 @@
               </select>
             </div>
             <div class="col-md-5">
-              <img src="img/themes/{{model.selectedTheme}}.jpg" width="250" class="thumbnail" style="border: 1px solid black"/>
+              <img ng-src="img/themes/{{model.selectedTheme}}.jpg" width="250" class="thumbnail" style="border: 1px solid black"/>
            </div>
         </div>
       <div class="modal-footer">


### PR DESCRIPTION
Fix "ng-src" image tag property for selectedTheme of model, this fails at runtime if you set "src" instead. Therefore we need to change it to "ng-src".